### PR TITLE
V2.10.0

### DIFF
--- a/src/BuildingBlocks/Daikon.Shared/APIClients/MLogix/MLogixAPI_BASE.cs
+++ b/src/BuildingBlocks/Daikon.Shared/APIClients/MLogix/MLogixAPI_BASE.cs
@@ -47,7 +47,7 @@ namespace Daikon.Shared.APIClients.MLogix
                 if (content != null && (method == HttpMethod.Post || method == HttpMethod.Put || method.Method == "PATCH"))
                 {
                     request.Content = new StringContent(JsonSerializer.Serialize(content, _jsonOptions), Encoding.UTF8, "application/json");
-                    _logger.LogDebug("API request content: {Content}", request.Content.ReadAsStringAsync().Result);
+                    //_logger.LogDebug("API request content: {Content}", request.Content.ReadAsStringAsync().Result);
                 }
 
                 HttpResponseMessage response = await _httpClient.SendAsync(request);

--- a/src/BuildingBlocks/Daikon.Shared/Constants/AppScreen/ScreeningMethod.cs
+++ b/src/BuildingBlocks/Daikon.Shared/Constants/AppScreen/ScreeningMethod.cs
@@ -14,6 +14,7 @@ namespace Daikon.Shared.Constants.AppScreen
         public const string Other = "other";
         public const string Hypomorph = "hypomorph";
         public const string Virtual = "virtual";
+        public const string Affinity = "affinity";
 
         public static List<NameValuePair> GetScreeningMethods()
         {
@@ -25,6 +26,7 @@ namespace Daikon.Shared.Constants.AppScreen
                 new() { Name = "Other", Value = Other },
                 new() { Name = "Hypomorph", Value = Hypomorph },
                 new() { Name = "Virtual", Value = Virtual },
+                new() { Name = "Affinity", Value = Affinity },
             }.OrderBy(dv => dv.Name)];
         }
     }

--- a/src/BuildingBlocks/Daikon.Shared/ConstantsVM.cs
+++ b/src/BuildingBlocks/Daikon.Shared/ConstantsVM.cs
@@ -15,7 +15,7 @@ namespace Daikon.Shared
             {
                 AppVersion = new
                 {
-                    Version = "2.9.2",
+                    Version = "2.10.0",
                     Name = "Valparaíso"
                 },
                 AppTarget = new

--- a/src/BuildingBlocks/Daikon.Shared/DTO/MLogix/RegisterMoleculeRequest.cs
+++ b/src/BuildingBlocks/Daikon.Shared/DTO/MLogix/RegisterMoleculeRequest.cs
@@ -12,5 +12,7 @@ namespace Daikon.Shared.DTO.MLogix
         public string SMILES { get; set; }
         public Dictionary<string, string>? Ids { get; set; }
         public string? DisclosureStage { get; set; } = string.Empty;
+        public string DisclosureScientist { get; set; } = string.Empty;
+        public Guid DisclosureOrgId { get; set; } = Guid.Empty;
     }
 }

--- a/src/Services/MLogix/MLogix.Application/Features/Commands/DiscloseMolecule/DiscloseMoleculeBatchHandler.cs
+++ b/src/Services/MLogix/MLogix.Application/Features/Commands/DiscloseMolecule/DiscloseMoleculeBatchHandler.cs
@@ -130,7 +130,7 @@ namespace MLogix.Application.Features.Commands.DiscloseMolecule
                 moleculeDisclosedEvent.StructureDisclosedByUserId = request.RequestorUserId;
                 moleculeDisclosedEvent.IsStructureDisclosed = true;
                 moleculeDisclosedEvent.DisclosureScientist = molecule.DisclosureScientist ?? scientist;
-                moleculeDisclosedEvent.DisclosureOrgId = disclosureOrgId;
+                moleculeDisclosedEvent.DisclosureOrgId = molecule.DisclosureOrgId == Guid.Empty ? disclosureOrgId : molecule.DisclosureOrgId;
 
                 try
                 {

--- a/src/Services/MLogix/MLogix.Application/Features/Commands/DiscloseMolecule/DiscloseMoleculeCommand.cs
+++ b/src/Services/MLogix/MLogix.Application/Features/Commands/DiscloseMolecule/DiscloseMoleculeCommand.cs
@@ -24,6 +24,7 @@ namespace MLogix.Application.Features.Commands.DiscloseMolecule
 
         // Name of the scientist who performed the disclosure
         public string DisclosureScientist { get; set; } = string.Empty;
+        public Guid DisclosureOrgId { get; set; } = Guid.Empty;
 
         // Reason for disclosing the structure (e.g., "collaboration", "publication", "patent filing")
         public string DisclosureReason { get; set; } = string.Empty;

--- a/src/Services/MLogix/MLogix.Application/Features/Commands/RegisterMolecule/RegisterMoleculeCommand.cs
+++ b/src/Services/MLogix/MLogix.Application/Features/Commands/RegisterMolecule/RegisterMoleculeCommand.cs
@@ -10,6 +10,9 @@ namespace MLogix.Application.Features.Commands.RegisterMolecule
         public string SMILES { get; set; } = string.Empty;
         public string? Synonyms { get; set; }
         public string? DisclosureStage { get; set; } = string.Empty;
+        public string DisclosureScientist { get; set; } = string.Empty;
+        public Guid DisclosureOrgId { get; set; } = Guid.Empty;
+        
 
     }
 }

--- a/src/Services/Screen/Screen.Application/Features/Commands/NewHit/NewHitCommand.cs
+++ b/src/Services/Screen/Screen.Application/Features/Commands/NewHit/NewHitCommand.cs
@@ -128,5 +128,11 @@ namespace Screen.Application.Features.Commands.NewHit
         public DVariable<string>? RequestedSMILES { get; set; }
         public required string MoleculeName { get; set; }
 
+        /* Disclosure Information */
+
+        public string DisclosureScientist { get; set; } = string.Empty;
+        public Guid DisclosureOrgId { get; set; } = Guid.Empty;
+
+
     }
 }

--- a/src/Services/Screen/Screen.Application/Features/Commands/NewHit/NewHitCommandHandler.cs
+++ b/src/Services/Screen/Screen.Application/Features/Commands/NewHit/NewHitCommandHandler.cs
@@ -78,7 +78,9 @@ namespace Screen.Application.Features.Commands.NewHit
                 {
                     Name = request.MoleculeName,
                     SMILES = request.RequestedSMILES.Value,
-                    DisclosureStage = Daikon.Shared.Constants.Workflow.Stages.Screen
+                    DisclosureStage = Daikon.Shared.Constants.Workflow.Stages.Screen,
+                    DisclosureScientist = request.DisclosureScientist,
+                    DisclosureOrgId = request.DisclosureOrgId
                 });
 
                 eventToAdd.MoleculeId = response.Id;

--- a/src/Services/Screen/Screen.Application/Features/Commands/NewHitBatch/RegisterHitBatchHandler.cs
+++ b/src/Services/Screen/Screen.Application/Features/Commands/NewHitBatch/RegisterHitBatchHandler.cs
@@ -58,7 +58,9 @@ namespace Screen.Application.Features.Commands.NewHitBatch
                 {
                     Name = cmd.MoleculeName,
                     SMILES = cmd.RequestedSMILES,
-                    DisclosureStage = Daikon.Shared.Constants.Workflow.Stages.Screen
+                    DisclosureStage = Daikon.Shared.Constants.Workflow.Stages.Screen,
+                    DisclosureScientist = cmd.DisclosureScientist,
+                    DisclosureOrgId = cmd.DisclosureOrgId
 
                 }).ToList();
 

--- a/src/Services/Screen/Screen.Application/Features/Commands/NewHitBatch/RegisterHitBatchHandler.cs
+++ b/src/Services/Screen/Screen.Application/Features/Commands/NewHitBatch/RegisterHitBatchHandler.cs
@@ -65,7 +65,29 @@ namespace Screen.Application.Features.Commands.NewHitBatch
                 var registrationResults = await _mLogixAPIService.RegisterBatch(moleculeDTOs);
                 _logger.LogInformation("✅ Registered {Count} molecules", registrationResults.Count);
 
-                var resultMap = registrationResults.ToDictionary(r => r.Name, r => r);
+                //var resultMap = registrationResults.ToDictionary(r => r.Name, r => r);
+                /* Index by Name and Synonyms as well */
+                var resultMap = new Dictionary<string, MoleculeVM>(StringComparer.OrdinalIgnoreCase);
+                foreach (var r in registrationResults)
+                {
+                    // Always add the official name
+                    if (!string.IsNullOrWhiteSpace(r.Name))
+                        resultMap[r.Name] = r;
+
+                    // Add each synonym as a key too
+                    if (!string.IsNullOrWhiteSpace(r.Synonyms))
+                    {
+                        var synonyms = r.Synonyms.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                        foreach (var syn in synonyms)
+                        {
+                            var key = syn.Trim();
+                            if (!string.IsNullOrEmpty(key))
+                                resultMap[key] = r;
+                        }
+                    }
+                }
+
+
 
                 // Step 3: Group all hits by HitCollectionId
                 var grouped = batch.GroupBy(cmd => cmd.Id);

--- a/src/Services/Target/Target.API/Controllers/V2/TargetController_TPQ.cs
+++ b/src/Services/Target/Target.API/Controllers/V2/TargetController_TPQ.cs
@@ -3,6 +3,7 @@ using System.Net;
 using CQRS.Core.Responses;
 using Microsoft.AspNetCore.Mvc;
 using Target.Application.Features.Commands.ApproveTarget;
+using Target.Application.Features.Commands.RejectTarget;
 using Target.Application.Features.Commands.SubmitTPQ;
 using Target.Application.Features.Commands.UpdateTPQ;
 using Target.Application.Features.Queries.ListTPQRespUnverified;
@@ -88,6 +89,19 @@ namespace Target.API.Controllers.V2
 
         }
 
-
+        // Reject & Delete
+        [HttpDelete("tpq/{tpqId}", Name = "RejectTPQ")]
+        [MapToApiVersion("2.0")]
+        [ProducesResponseType(typeof(BaseResponse), (int)HttpStatusCode.OK)]
+        public async Task<ActionResult<BaseResponse>> RejectTPQ(Guid tpqId)
+        {
+            var rejectTargetCommand = new RejectTargetCommand { Id = tpqId };
+            var response = await _mediator.Send(rejectTargetCommand);
+            return StatusCode(StatusCodes.Status200OK, new AddResponse
+            {
+                Id = tpqId,
+                Message = "TPQ rejected successfully.",
+            });
+        }
     }
 }

--- a/src/Services/Target/Target.Application/Features/Commands/ApproveTarget/ApproveTargetHandler.cs
+++ b/src/Services/Target/Target.Application/Features/Commands/ApproveTarget/ApproveTargetHandler.cs
@@ -38,7 +38,7 @@ namespace Target.Application.Features.Commands.ApproveTarget
         {
             // check if target (targetName) already exists within same strain ; reject if it does
             var existingTarget = await _targetRepository.ReadTargetByName(request.TargetName);
-            if (existingTarget!= null && 
+            if (existingTarget != null &&
                 (existingTarget.Name == request.TargetName && existingTarget.StrainId == request.StrainId))
             {
                 throw new DuplicateEntityRequestException(nameof(ApproveTargetCommand), request.TargetName);
@@ -71,7 +71,7 @@ namespace Target.Application.Features.Commands.ApproveTarget
 
 
             await _mediator.Send(newTargetCommand, cancellationToken);
-            _logger.LogInformation(" +++++++++++++++++ New Target created with Name {TargetName}", request.TargetName);
+            _logger.LogInformation("New Target created with Name {TargetName}", request.TargetName);
 
             // now update the TPQ to reflect the new target
 
@@ -95,8 +95,9 @@ namespace Target.Application.Features.Commands.ApproveTarget
                 _logger.LogError(ex, "Aggregate not found");
             }
 
-            _logger.LogInformation(" +++++++++++++++++ TPQ updated with new target");
+            _logger.LogInformation("TPQ updated with new target");
 
-            return Unit.Value;        }
+            return Unit.Value;
+        }
     }
 }

--- a/src/Services/Target/Target.Application/Features/Commands/RejectTarget/RejectTargetCommand.cs
+++ b/src/Services/Target/Target.Application/Features/Commands/RejectTarget/RejectTargetCommand.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CQRS.Core.Command;
+using MediatR;
+
+namespace Target.Application.Features.Commands.RejectTarget
+{
+    public class RejectTargetCommand : BaseCommand, IRequest<Unit>
+    {
+        
+    }
+}

--- a/src/Services/Target/Target.Application/Features/Commands/RejectTarget/RejectTargetHandler.cs
+++ b/src/Services/Target/Target.Application/Features/Commands/RejectTarget/RejectTargetHandler.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using CQRS.Core.Exceptions;
+using Daikon.Events.Targets;
+using Daikon.EventStore.Handlers;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Target.Domain.Aggregates;
+
+namespace Target.Application.Features.Commands.RejectTarget
+{
+    public class RejectTargetHandler : IRequestHandler<RejectTargetCommand, Unit>
+    {
+        private readonly ILogger<RejectTargetHandler> _logger;
+        private readonly IEventSourcingHandler<TPQuestionnaireAggregate> _questionnaireESH;
+        private readonly IMapper _mapper;
+
+        public RejectTargetHandler(ILogger<RejectTargetHandler> logger, IEventSourcingHandler<TPQuestionnaireAggregate> questionnaireESH, IMapper mapper)
+        {
+            _logger = logger;
+            _questionnaireESH = questionnaireESH;
+            _mapper = mapper;
+        }
+
+        public async Task<Unit> Handle(RejectTargetCommand request, CancellationToken cancellationToken)
+        {
+            request.SetUpdateProperties(request.RequestorUserId);
+            _logger.LogInformation("Handling rejection for target: {TargetId}", request.Id);
+            try
+            {
+                var aggregate = await _questionnaireESH.GetByAsyncId(request.Id);
+
+                var targetRejectedEvent = _mapper.Map<TargetPromotionQuestionnaireDeletedEvent>(request);
+
+                aggregate.DeletePQResponse(targetRejectedEvent);
+                _logger.LogInformation("Target rejected: {TargetId}", request.Id);
+
+                await _questionnaireESH.SaveAsync(aggregate);
+            }
+            catch (AggregateNotFoundException ex)
+            {
+                _logger.LogWarning(ex, "Aggregate not found");
+                throw new ResourceNotFoundException(nameof(TargetAggregate), request.Id);
+            }
+            return Unit.Value;
+        }
+    }
+}

--- a/src/Services/Target/Target.Application/Mappings/MappingProfile.cs
+++ b/src/Services/Target/Target.Application/Mappings/MappingProfile.cs
@@ -13,6 +13,7 @@ using Target.Application.Features.Commands.AddOrUpdateToxicology;
 using Target.Application.Features.Commands.AddToxicology;
 using Target.Application.Features.Commands.ApproveTarget;
 using Target.Application.Features.Commands.DeleteToxicology;
+using Target.Application.Features.Commands.RejectTarget;
 using Target.Application.Features.Commands.RenameTarget;
 using Target.Application.Features.Commands.SubmitTPQ;
 using Target.Application.Features.Commands.UpdateToxicology;
@@ -44,6 +45,7 @@ namespace Target.Application.Mappings
             CreateMap<TargetUpdatedEvent, Domain.Entities.Target>().ReverseMap();
             CreateMap<TargetDeletedEvent, Domain.Entities.Target>().ReverseMap();
             CreateMap<TargetRenamedEvent, Domain.Entities.Target>().ReverseMap();
+
 
             CreateMap<Domain.Entities.Target, TargetVM>()
             .ForMember(dest => dest.Bucket, opt => opt.MapFrom(new MapperDVariableMetaResolver<Domain.Entities.Target, IValueProperty<string>, string>(src => src.Bucket)))
@@ -112,6 +114,8 @@ namespace Target.Application.Mappings
 
             CreateMap<TargetPromotionQuestionnaireSubmittedEvent, SubmitTPQCommand>().ReverseMap();
             CreateMap<TargetPromotionQuestionnaireUpdatedEvent, UpdateTPQCommand>().ReverseMap();
+            CreateMap<TargetPromotionQuestionnaireDeletedEvent, RejectTargetCommand>().ReverseMap();
+
 
             // Command to Domain
             CreateMap<NewTargetCommand, Domain.Entities.Target>().ReverseMap();

--- a/src/docker-compose.infra.yml
+++ b/src/docker-compose.infra.yml
@@ -47,7 +47,7 @@ services:
     container_name: "eventstoredb"
     image: mongo:jammy
     restart: always
-    cpus: '0.1'
+    cpus: '1.0'
     ports:
       - "27017:27017"
     volumes:


### PR DESCRIPTION
This pull request introduces several important enhancements and fixes across molecule registration, disclosure handling, and target management. The main changes add support for tracking disclosure scientist and organization throughout molecule workflows, improve batch registration logging and mapping, and add the ability to reject and delete TPQ targets via the API.

### Molecule Disclosure & Registration Improvements

* Added `DisclosureScientist` and `DisclosureOrgId` fields to molecule registration and disclosure DTOs, commands, and event handling, ensuring these details are tracked and propagated throughout batch and single molecule operations. [[1]](diffhunk://#diff-7c57d6407a47e229312370917a2f943937df07d6c3e430f2bb7a401139db46ceR15-R16) [[2]](diffhunk://#diff-32312ddde8571a45a747385c0b4c750e326b1ace16c047df2828c663932cfd1aR13-R15) [[3]](diffhunk://#diff-99eec4e8dbb84968bdf84000dcd57de70df2b1f61517975df4e21382f2377804R27) [[4]](diffhunk://#diff-b67dca19d3901a80643874d97478b1f396fba31d351fa52636227d141ad666dfL17-R17) [[5]](diffhunk://#diff-b67dca19d3901a80643874d97478b1f396fba31d351fa52636227d141ad666dfL66-R66) [[6]](diffhunk://#diff-b67dca19d3901a80643874d97478b1f396fba31d351fa52636227d141ad666dfL112-R113) [[7]](diffhunk://#diff-b67dca19d3901a80643874d97478b1f396fba31d351fa52636227d141ad666dfR166-R176) [[8]](diffhunk://#diff-b67dca19d3901a80643874d97478b1f396fba31d351fa52636227d141ad666dfL185-R209) [[9]](diffhunk://#diff-b67dca19d3901a80643874d97478b1f396fba31d351fa52636227d141ad666dfL207-R226) [[10]](diffhunk://#diff-857e708cb33839599c904b5f4b691f0bb9eafb9b050be9fbd7a1c14da6fcfa11L133-R133) [[11]](diffhunk://#diff-9c9bdef80e3f4de06971c6782045aeef1c9522bf1b5d8e9de06f398d58554b43R131-R136) [[12]](diffhunk://#diff-7af0dfa84327faa553cb9722934648b968b78b3c6fa7120b3cf82ddddfe260cfL81-R83) [[13]](diffhunk://#diff-e8303ccc937da78becb16dced581bbee2b1b606d8d72a350fea460497627809bL61-R92)

* Improved batch registration mapping and logging to include disclosure scientist and organization, ensuring that molecule provenance is accurately recorded and retrievable. [[1]](diffhunk://#diff-b67dca19d3901a80643874d97478b1f396fba31d351fa52636227d141ad666dfL17-R17) [[2]](diffhunk://#diff-b67dca19d3901a80643874d97478b1f396fba31d351fa52636227d141ad666dfL66-R66) [[3]](diffhunk://#diff-b67dca19d3901a80643874d97478b1f396fba31d351fa52636227d141ad666dfL112-R113) [[4]](diffhunk://#diff-b67dca19d3901a80643874d97478b1f396fba31d351fa52636227d141ad666dfR166-R176) [[5]](diffhunk://#diff-b67dca19d3901a80643874d97478b1f396fba31d351fa52636227d141ad666dfL185-R209) [[6]](diffhunk://#diff-b67dca19d3901a80643874d97478b1f396fba31d351fa52636227d141ad666dfL207-R226)

### Target Management API Enhancements

* Added a new API endpoint and handler to reject and delete TPQ targets, including the `RejectTargetCommand` and `RejectTargetHandler`, allowing users to remove TPQ entries via a DELETE request. [[1]](diffhunk://#diff-4ae8f05b41a730fa278391d7245e95b1643e312d693b3f9dfadabb8cdea80e9eR6) [[2]](diffhunk://#diff-4ae8f05b41a730fa278391d7245e95b1643e312d693b3f9dfadabb8cdea80e9eL91-R105) [[3]](diffhunk://#diff-09ebc5b08e990c10b97c72e75f7392e9eb9df1a61786e1015e8f7a8da187ceb5R1-R14) [[4]](diffhunk://#diff-a7594ad34f67098b198b94074ff6028441d75bfdbaa4c58071df81344713d056R1-R51)

### Other Improvements

* Added a new screening method constant `Affinity` to `ScreeningMethod` and included it in the available options. [[1]](diffhunk://#diff-e2cbe249c9feb01537d9cbbac1185a86a84a1f8d0d6071956de95e9383aabccdR17) [[2]](diffhunk://#diff-e2cbe249c9feb01537d9cbbac1185a86a84a1f8d0d6071956de95e9383aabccdR29)
* Updated the application version to `2.10.0` in `ConstantsVM.cs`.
* Improved molecule registration batch result mapping to index by both name and synonyms for more robust lookup.

### Minor Fixes & Cleanups

* Commented out a debug log for API request content to reduce noise.
* Cleaned up log messages in target approval handler for clarity. [[1]](diffhunk://#diff-cd9cd0d4091e614217842318aae07e6d1a5b348444c4e385d0fa5774f57dccd5L74-R74) [[2]](diffhunk://#diff-cd9cd0d4091e614217842318aae07e6d1a5b348444c4e385d0fa5774f57dccd5L98-R101)