### PR TITLE
Enforce target aggregate invariants

### DIFF
--- a/src/Services/Target/Target.Domain/Aggregates/TargetAggregate_Toxicology.cs
+++ b/src/Services/Target/Target.Domain/Aggregates/TargetAggregate_Toxicology.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Daikon.Events.Targets;
 using Target.Domain.Entities;
+using Target.Domain.Exceptions;
 
 namespace Target.Domain.Aggregates
 {

--- a/src/Services/Target/Target.Domain/Exceptions/DomainInvariantViolationException.cs
+++ b/src/Services/Target/Target.Domain/Exceptions/DomainInvariantViolationException.cs
@@ -1,0 +1,6 @@
+namespace Target.Domain.Exceptions
+{
+    public class DomainInvariantViolationException(string message) : Exception(message)
+    {
+    }
+}

--- a/src/Services/Target/Target.Domain/Services/ITargetUniquenessChecker.cs
+++ b/src/Services/Target/Target.Domain/Services/ITargetUniquenessChecker.cs
@@ -1,0 +1,7 @@
+namespace Target.Domain.Services
+{
+    public interface ITargetUniquenessChecker
+    {
+        Task EnsureTargetNameIsUniqueAsync(Guid strainId, string name, Guid? existingTargetId = null);
+    }
+}

--- a/src/Services/Target/Target.Infrastructure/DomainServices/TargetUniquenessChecker.cs
+++ b/src/Services/Target/Target.Infrastructure/DomainServices/TargetUniquenessChecker.cs
@@ -1,0 +1,45 @@
+using Daikon.EventStore.Repositories;
+using Daikon.Events.Targets;
+using Target.Domain.Aggregates;
+using Target.Domain.Exceptions;
+using Target.Domain.Services;
+
+namespace Target.Infrastructure.DomainServices
+{
+    public class TargetUniquenessChecker(IEventStoreRepository eventStoreRepository, ILogger<TargetUniquenessChecker> logger) : ITargetUniquenessChecker
+    {
+        private readonly IEventStoreRepository _eventStoreRepository = eventStoreRepository ?? throw new ArgumentNullException(nameof(eventStoreRepository));
+        private readonly ILogger<TargetUniquenessChecker> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        public async Task EnsureTargetNameIsUniqueAsync(Guid strainId, string name, Guid? existingTargetId = null)
+        {
+            var aggregateIds = await _eventStoreRepository.GetAllAggregateIds().ConfigureAwait(false);
+
+            foreach (var aggregateId in aggregateIds)
+            {
+                if (existingTargetId.HasValue && existingTargetId.Value == aggregateId)
+                {
+                    continue;
+                }
+
+                var events = await _eventStoreRepository.FindByAggregateId(aggregateId).ConfigureAwait(false);
+                var createdEvent = events
+                    .Where(@event => string.Equals(@event.AggregateType, nameof(TargetAggregate), StringComparison.OrdinalIgnoreCase))
+                    .Select(@event => @event.EventData)
+                    .OfType<TargetCreatedEvent>()
+                    .FirstOrDefault();
+
+                if (createdEvent == null)
+                {
+                    continue;
+                }
+
+                if (createdEvent.StrainId == strainId && string.Equals(createdEvent.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogWarning("Duplicate target detected for strain {StrainId} with name {TargetName}", strainId, name);
+                    throw new DomainInvariantViolationException($"Target with name '{name}' already exists for strain '{strainId}'.");
+                }
+            }
+        }
+    }
+}

--- a/src/Services/Target/Target.Infrastructure/InfrastructureServiceRegistration.cs
+++ b/src/Services/Target/Target.Infrastructure/InfrastructureServiceRegistration.cs
@@ -13,6 +13,8 @@ using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 using Target.Application.Contracts.Persistence;
 using Target.Domain.Aggregates;
+using Target.Domain.Services;
+using Target.Infrastructure.DomainServices;
 using Target.Infrastructure.Query.Consumers;
 using Target.Infrastructure.Query.Repositories;
 
@@ -27,6 +29,7 @@ namespace Target.Infrastructure
 
             ConfigureEventDatabase(services, configuration);
             ConfigureKafkaProducer(services, configuration);
+            ConfigureDomainServices(services);
             ConfigureRepositories(services);
             ConfigureConsumers(services);
 
@@ -98,6 +101,11 @@ namespace Target.Infrastructure
             services.AddScoped<ITargetRepository, TargetRepository>();
             services.AddScoped<IPQResponseRepository, PQResponseRepository>();
             services.AddScoped<IToxicologyRepo, ToxicologyRepo>();
+        }
+
+        private static void ConfigureDomainServices(IServiceCollection services)
+        {
+            services.AddScoped<ITargetUniquenessChecker, TargetUniquenessChecker>();
         }
 
         private static void ConfigureConsumers(IServiceCollection services)


### PR DESCRIPTION
## Summary
- move target creation and update invariants into the aggregate, introducing a domain exception type
- add an event-store backed domain service to enforce target name uniqueness
- refactor target command handlers to rely on event sourcing and domain checks instead of read model repositories

## Testing
- `dotnet build src/Services/Target/Target.Application/Target.Application.csproj` *(fails: unable to reach https://api.nuget.org/v3/index.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693af284f080832c8593fe1bbfec8a76)