### PR TITLE
Add default `/health` and `/health/ready` endpoints to API defaults

### DIFF
--- a/src/BuildingBlocks/Daikon.ApiHost/WebApplicationExtensions.cs
+++ b/src/BuildingBlocks/Daikon.ApiHost/WebApplicationExtensions.cs
@@ -1,13 +1,17 @@
 using CQRS.Core.Middlewares;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using System.Reflection;
 
 namespace Daikon.ApiHost;
 
 public static class WebApplicationExtensions
 {
+    private static readonly DateTimeOffset StartedAt = DateTimeOffset.UtcNow;
+
     public static WebApplication UseDaikonApiDefaults(this WebApplication app)
     {
         Console.WriteLine($"Environment: {app.Environment.EnvironmentName}");
@@ -26,9 +30,41 @@ public static class WebApplicationExtensions
             });
         }
 
+        app.MapGet("/health", () => Results.Ok(BuildHealthResponse(app)));
+        app.MapGet("/health/ready", () => Results.Ok(BuildHealthResponse(app)));
         app.UseMiddleware<GlobalErrorHandlingMiddleware>();
         app.MapControllers();
 
         return app;
+    }
+
+    private static IDictionary<string, object?> BuildHealthResponse(WebApplication app)
+    {
+        var entryAssembly = Assembly.GetEntryAssembly();
+        var serviceName = app.Environment.ApplicationName ?? entryAssembly?.GetName().Name;
+        var version = entryAssembly?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? entryAssembly?.GetName().Version?.ToString();
+        var response = new Dictionary<string, object?>
+        {
+            ["service"] = serviceName,
+            ["version"] = version,
+            ["environment"] = app.Environment.EnvironmentName,
+            ["timestamp"] = DateTimeOffset.UtcNow,
+            ["uptime"] = DateTimeOffset.UtcNow - StartedAt
+        };
+
+        var commit = app.Configuration["Build:Commit"];
+        if (!string.IsNullOrWhiteSpace(commit))
+        {
+            response["commit"] = commit;
+        }
+
+        var buildNumber = app.Configuration["Build:BuildNumber"];
+        if (!string.IsNullOrWhiteSpace(buildNumber))
+        {
+            response["buildNumber"] = buildNumber;
+        }
+
+        return response;
     }
 }


### PR DESCRIPTION
### Motivation
- Expose a lightweight health endpoint from every service that calls `UseDaikonApiDefaults()` so services automatically surface basic health metadata without per-service changes.  
- Provide consistent runtime and build information (service, version, environment, timestamp, uptime, optional build info) to assist monitoring and readiness checks.  

### Description
- Added a static `StartedAt` timestamp and registered two minimal API routes with `app.MapGet` for `"/health"` and `"/health/ready"` in `src/BuildingBlocks/Daikon.ApiHost/WebApplicationExtensions.cs`.  
- Implemented `BuildHealthResponse(WebApplication app)` which returns a dictionary containing `service`, `version`, `environment`, `timestamp`, and `uptime`, and also includes optional `commit` and `buildNumber` when available from configuration keys `Build:Commit` and `Build:BuildNumber`.  
- The helper reads `app.Environment.ApplicationName` and falls back to `Assembly.GetEntryAssembly()` for `service` and `version`, and added required `using` directives (`Microsoft.AspNetCore.Http`, `System.Reflection`).  

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69742954d314832ca7dbad58a7e9384d)