### PR TITLE
Serialize health body as JSON when possible

### DIFF
--- a/src/ApiGateways/SimpleGW/SimpleGW.API/Program.cs
+++ b/src/ApiGateways/SimpleGW/SimpleGW.API/Program.cs
@@ -1,6 +1,7 @@
 
 using Microsoft.IdentityModel.Logging;
 using SimpleGW.API.Middlewares;
+using SimpleGW.API.Services;
 using SimpleGW.Contracts.Infrastructure;
 using SimpleGW.OIDCProviders;
 
@@ -46,6 +47,8 @@ try
             client.Timeout = TimeSpan.FromMinutes(5);
         });
     builder.Services.AddMemoryCache();
+    builder.Services.AddSingleton<IMicroserviceHealthStore, MicroserviceHealthStore>();
+    builder.Services.AddHostedService<MicroserviceHealthPoller>();
 
 
     builder.Services.AddScoped<IUserStoreAPIService, UserStoreAPIService>();
@@ -61,6 +64,17 @@ try
     var app = builder.Build();
 
     Console.WriteLine($"Environment: {app.Environment.EnvironmentName}");
+
+    app.Map("/health/services", healthApp =>
+    {
+        healthApp.Run(async context =>
+        {
+            var store = context.RequestServices.GetRequiredService<IMicroserviceHealthStore>();
+            var snapshot = store.GetSnapshot();
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsJsonAsync(snapshot, context.RequestAborted);
+        });
+    });
 
     app.UseRouting();
     app.UseAuthentication();

--- a/src/ApiGateways/SimpleGW/SimpleGW.API/Services/HealthPollingOptions.cs
+++ b/src/ApiGateways/SimpleGW/SimpleGW.API/Services/HealthPollingOptions.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace SimpleGW.API.Services
+{
+    public sealed class HealthPollingOptions
+    {
+        public int IntervalSeconds { get; init; } = 30;
+        public int TimeoutSeconds { get; init; } = 10;
+        public Dictionary<string, HealthPollingServiceOverride> ServiceOverrides { get; init; } =
+            new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public sealed class HealthPollingServiceOverride
+    {
+        public int? TimeoutSeconds { get; init; }
+        public string? HealthPath { get; init; }
+    }
+}

--- a/src/ApiGateways/SimpleGW/SimpleGW.API/Services/IMicroserviceHealthStore.cs
+++ b/src/ApiGateways/SimpleGW/SimpleGW.API/Services/IMicroserviceHealthStore.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace SimpleGW.API.Services
+{
+    public interface IMicroserviceHealthStore
+    {
+        IReadOnlyDictionary<string, MicroserviceHealthStatus> GetSnapshot();
+        void Update(string serviceName, MicroserviceHealthStatus status);
+    }
+}

--- a/src/ApiGateways/SimpleGW/SimpleGW.API/Services/MicroserviceHealthPoller.cs
+++ b/src/ApiGateways/SimpleGW/SimpleGW.API/Services/MicroserviceHealthPoller.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace SimpleGW.API.Services
+{
+    public sealed class MicroserviceHealthPoller : BackgroundService
+    {
+        private const string DefaultHealthPath = "/health";
+        private readonly IConfiguration _configuration;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IMicroserviceHealthStore _healthStore;
+        private readonly ILogger<MicroserviceHealthPoller> _logger;
+
+        public MicroserviceHealthPoller(
+            IConfiguration configuration,
+            IHttpClientFactory httpClientFactory,
+            IMicroserviceHealthStore healthStore,
+            ILogger<MicroserviceHealthPoller> logger)
+        {
+            _configuration = configuration;
+            _httpClientFactory = httpClientFactory;
+            _healthStore = healthStore;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var options = _configuration.GetSection("HealthPolling").Get<HealthPollingOptions>()
+                              ?? new HealthPollingOptions();
+                var interval = TimeSpan.FromSeconds(Math.Max(1, options.IntervalSeconds));
+                var timeoutSeconds = Math.Max(1, options.TimeoutSeconds);
+
+                var endPointRouting = _configuration.GetSection("EndPointRouting").Get<Dictionary<string, string>>()
+                                      ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+                if (endPointRouting.Count == 0)
+                {
+                    _logger.LogWarning("EndPointRouting configuration is empty; skipping health polling.");
+                }
+                else
+                {
+                    var client = _httpClientFactory.CreateClient("SimpleGWClient");
+                    foreach (var route in endPointRouting)
+                    {
+                        var serviceName = route.Key;
+                        var baseUrl = route.Value;
+                        var serviceOverride = options.ServiceOverrides.TryGetValue(serviceName, out var overrideOptions)
+                            ? overrideOptions
+                            : null;
+                        var healthPath = serviceOverride?.HealthPath ?? DefaultHealthPath;
+                        var serviceTimeoutSeconds = Math.Max(1, serviceOverride?.TimeoutSeconds ?? timeoutSeconds);
+                        var healthUrl = $"{baseUrl.TrimEnd('/')}/{healthPath.TrimStart('/')}";
+                        var checkedAt = DateTimeOffset.UtcNow;
+
+                        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+                        timeoutCts.CancelAfter(TimeSpan.FromSeconds(serviceTimeoutSeconds));
+
+                        try
+                        {
+                            var response = await client.GetAsync(healthUrl, timeoutCts.Token);
+                            var body = await response.Content.ReadAsStringAsync(timeoutCts.Token);
+                            var bodyPayload = TryParseJson(body, out var parsedBody)
+                                ? parsedBody
+                                : body;
+
+                            _healthStore.Update(
+                                serviceName,
+                                new MicroserviceHealthStatus((int)response.StatusCode, bodyPayload, checkedAt, null));
+                        }
+                        catch (Exception ex) when (!stoppingToken.IsCancellationRequested)
+                        {
+                            _logger.LogWarning(ex, "Health check failed for {ServiceName} at {HealthUrl}", serviceName, healthUrl);
+                            _healthStore.Update(
+                                serviceName,
+                                new MicroserviceHealthStatus(null, null, checkedAt, ex.Message));
+                        }
+                    }
+                }
+
+                try
+                {
+                    await Task.Delay(interval, stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+        }
+
+        private static bool TryParseJson(string body, out JsonElement parsed)
+        {
+            parsed = default;
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                return false;
+            }
+
+            try
+            {
+                using var document = JsonDocument.Parse(body);
+                parsed = document.RootElement.Clone();
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/ApiGateways/SimpleGW/SimpleGW.API/Services/MicroserviceHealthStatus.cs
+++ b/src/ApiGateways/SimpleGW/SimpleGW.API/Services/MicroserviceHealthStatus.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace SimpleGW.API.Services
+{
+    public sealed record MicroserviceHealthStatus(
+        int? StatusCode,
+        object? Body,
+        DateTimeOffset LastCheckedUtc,
+        string? Error);
+}

--- a/src/ApiGateways/SimpleGW/SimpleGW.API/Services/MicroserviceHealthStore.cs
+++ b/src/ApiGateways/SimpleGW/SimpleGW.API/Services/MicroserviceHealthStore.cs
@@ -1,0 +1,21 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace SimpleGW.API.Services
+{
+    public sealed class MicroserviceHealthStore : IMicroserviceHealthStore
+    {
+        private readonly ConcurrentDictionary<string, MicroserviceHealthStatus> _statuses =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        public IReadOnlyDictionary<string, MicroserviceHealthStatus> GetSnapshot()
+        {
+            return new Dictionary<string, MicroserviceHealthStatus>(_statuses, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public void Update(string serviceName, MicroserviceHealthStatus status)
+        {
+            _statuses[serviceName] = status;
+        }
+    }
+}

--- a/src/ApiGateways/SimpleGW/SimpleGW.API/appsettings.json
+++ b/src/ApiGateways/SimpleGW/SimpleGW.API/appsettings.json
@@ -34,6 +34,16 @@
     "event-management": "http://localhost:8015",
     "aggregators": "http://localhost:8017"
   },
+  "HealthPolling": {
+    "IntervalSeconds": 30,
+    "TimeoutSeconds": 5,
+    "ServiceOverrides": {
+      "user": {
+        "TimeoutSeconds": 10,
+        "HealthPath": "/health"
+      }
+    }
+  },
 
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
### Motivation
- Health check responses were being stored as escaped JSON strings which caused the gateway `/health/services` response to include stringified JSON bodies instead of structured objects.
- The goal is to surface structured health payloads when services return JSON while preserving raw text bodies for non-JSON responses.

### Description
- Parse health response bodies in `MicroserviceHealthPoller` using `TryParseJson` and store either a parsed `JsonElement` or the original string as the `Body` field.
- Change `MicroserviceHealthStatus` to hold a generic `object? Body` so the store can carry structured JSON or raw text.
- Implement `TryParseJson` which uses `JsonDocument.Parse` and clones the root element to produce a `JsonElement` when parsing succeeds. 
- Added/registered supporting types and wiring: `HealthPollingOptions`, `IMicroserviceHealthStore`, `MicroserviceHealthStore`, `MicroserviceHealthPoller`, and expose the snapshot at `/health/services` in `Program.cs` so clients receive structured bodies where available.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697429f06aa8832c97b1693edc113394)