### PR TITLE
Fix CORS handling for /health/services in SimpleGW

### DIFF
--- a/src/ApiGateways/SimpleGW/SimpleGW.API/Program.cs
+++ b/src/ApiGateways/SimpleGW/SimpleGW.API/Program.cs
@@ -65,6 +65,11 @@ try
 
     Console.WriteLine($"Environment: {app.Environment.EnvironmentName}");
 
+    app.UseRouting();
+    app.UseCors("AllowAll");
+    app.UseAuthentication();
+    app.UseAuthorization();
+
     app.Map("/health/services", healthApp =>
     {
         healthApp.Run(async context =>
@@ -75,11 +80,6 @@ try
             await context.Response.WriteAsJsonAsync(snapshot, context.RequestAborted);
         });
     });
-
-    app.UseRouting();
-    app.UseAuthentication();
-    app.UseAuthorization();
-    app.UseCors("AllowAll");
 
     app.UseMiddleware<RequestTimingMiddleware>();
     app.UseMiddleware<AuthenticationValidatorMiddleware>();


### PR DESCRIPTION
### Motivation
- Browser preflight requests to `http://localhost:8010/health/services` were failing because the `/health/services` route was mapped before the CORS middleware, so responses did not include `Access-Control-Allow-Origin` headers.

### Description
- Move `app.UseRouting()`, `app.UseCors("AllowAll")`, `app.UseAuthentication()`, and `app.UseAuthorization()` ahead of `app.Map("/health/services", ...)` in `src/ApiGateways/SimpleGW/SimpleGW.API/Program.cs` so the health endpoint is executed through the CORS middleware.
- Retain the existing `AllowAll` CORS policy which uses `AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader()`.

### Testing
- Ran `dotnet build src/daikon.sln`, which failed in this environment because the `dotnet` command is not available (`dotnet: command not found`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69743bc46b80832cbcf58cda0acadedd)