### PR TITLE
Add external health polling targets

### DIFF
--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -2,6 +2,7 @@
   "cSpell.words": [
     "ASPNETCORE",
     "Bson",
+    "chemvault",
     "Crispr",
     "Crispri",
     "Docu",

--- a/src/ApiGateways/SimpleGW/SimpleGW.API/Services/HealthPollingOptions.cs
+++ b/src/ApiGateways/SimpleGW/SimpleGW.API/Services/HealthPollingOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace SimpleGW.API.Services
@@ -8,11 +9,20 @@ namespace SimpleGW.API.Services
         public int TimeoutSeconds { get; init; } = 10;
         public Dictionary<string, HealthPollingServiceOverride> ServiceOverrides { get; init; } =
             new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, HealthPollingTarget> ExternalServices { get; init; } =
+            new(StringComparer.OrdinalIgnoreCase);
     }
 
     public sealed class HealthPollingServiceOverride
     {
         public int? TimeoutSeconds { get; init; }
         public string? HealthPath { get; init; }
+    }
+
+    public sealed class HealthPollingTarget
+    {
+        public string BaseUrl { get; init; } = string.Empty;
+        public string? HealthPath { get; init; }
+        public int? TimeoutSeconds { get; init; }
     }
 }

--- a/src/ApiGateways/SimpleGW/SimpleGW.API/Services/MicroserviceHealthPoller.cs
+++ b/src/ApiGateways/SimpleGW/SimpleGW.API/Services/MicroserviceHealthPoller.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,27 +42,52 @@ namespace SimpleGW.API.Services
                 var endPointRouting = _configuration.GetSection("EndPointRouting").Get<Dictionary<string, string>>()
                                       ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-                if (endPointRouting.Count == 0)
+                var externalServices = options.ExternalServices ??
+                                       new Dictionary<string, HealthPollingTarget>(StringComparer.OrdinalIgnoreCase);
+
+                if (endPointRouting.Count == 0 && externalServices.Count == 0)
                 {
-                    _logger.LogWarning("EndPointRouting configuration is empty; skipping health polling.");
+                    _logger.LogWarning("EndPointRouting and HealthPolling:ExternalServices are empty; skipping health polling.");
                 }
                 else
                 {
                     var client = _httpClientFactory.CreateClient("SimpleGWClient");
-                    foreach (var route in endPointRouting)
+
+                    var targets = new List<PollTarget>();
+
+                    targets.AddRange(endPointRouting.Select(route =>
                     {
                         var serviceName = route.Key;
-                        var baseUrl = route.Value;
                         var serviceOverride = options.ServiceOverrides.TryGetValue(serviceName, out var overrideOptions)
                             ? overrideOptions
                             : null;
                         var healthPath = serviceOverride?.HealthPath ?? DefaultHealthPath;
                         var serviceTimeoutSeconds = Math.Max(1, serviceOverride?.TimeoutSeconds ?? timeoutSeconds);
-                        var healthUrl = $"{baseUrl.TrimEnd('/')}/{healthPath.TrimStart('/')}";
+                        return new PollTarget(serviceName, route.Value, healthPath, serviceTimeoutSeconds);
+                    }));
+
+                    targets.AddRange(externalServices.Select(external =>
+                    {
+                        var serviceName = external.Key;
+                        var target = external.Value;
+                        var healthPath = target.HealthPath ?? DefaultHealthPath;
+                        var serviceTimeoutSeconds = Math.Max(1, target.TimeoutSeconds ?? timeoutSeconds);
+                        return new PollTarget(serviceName, target.BaseUrl, healthPath, serviceTimeoutSeconds);
+                    }));
+
+                    foreach (var target in targets)
+                    {
+                        if (string.IsNullOrWhiteSpace(target.BaseUrl))
+                        {
+                            _logger.LogWarning("Health polling base URL is empty for {ServiceName}; skipping.", target.ServiceName);
+                            continue;
+                        }
+
+                        var healthUrl = $"{target.BaseUrl.TrimEnd('/')}/{target.HealthPath.TrimStart('/')}";
                         var checkedAt = DateTimeOffset.UtcNow;
 
                         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
-                        timeoutCts.CancelAfter(TimeSpan.FromSeconds(serviceTimeoutSeconds));
+                        timeoutCts.CancelAfter(TimeSpan.FromSeconds(target.TimeoutSeconds));
 
                         try
                         {
@@ -72,14 +98,14 @@ namespace SimpleGW.API.Services
                                 : body;
 
                             _healthStore.Update(
-                                serviceName,
+                                target.ServiceName,
                                 new MicroserviceHealthStatus((int)response.StatusCode, bodyPayload, checkedAt, null));
                         }
                         catch (Exception ex) when (!stoppingToken.IsCancellationRequested)
                         {
-                            _logger.LogWarning(ex, "Health check failed for {ServiceName} at {HealthUrl}", serviceName, healthUrl);
+                            _logger.LogWarning(ex, "Health check failed for {ServiceName} at {HealthUrl}", target.ServiceName, healthUrl);
                             _healthStore.Update(
-                                serviceName,
+                                target.ServiceName,
                                 new MicroserviceHealthStatus(null, null, checkedAt, ex.Message));
                         }
                     }
@@ -95,8 +121,6 @@ namespace SimpleGW.API.Services
                 }
             }
         }
-
-
 
         private static bool TryParseJson(string body, out JsonElement parsed)
         {
@@ -117,9 +141,7 @@ namespace SimpleGW.API.Services
                 return false;
             }
         }
+
+        private sealed record PollTarget(string ServiceName, string BaseUrl, string HealthPath, int TimeoutSeconds);
     }
-
 }
-
-
-

--- a/src/ApiGateways/SimpleGW/SimpleGW.API/appsettings.json
+++ b/src/ApiGateways/SimpleGW/SimpleGW.API/appsettings.json
@@ -44,13 +44,15 @@
       }
     },
     "ExternalServices": {
-      "external:foo": {
-        "BaseUrl": "https://example-foo.local",
+      "external-cf-nuisance": {
+        "BaseUrl": "http://localhost:10002/cage-fusion-api",
         "HealthPath": "/health",
-        "TimeoutSeconds": 3
+        "TimeoutSeconds": 5
       },
-      "external:bar": {
-        "BaseUrl": "https://example-bar.local"
+      "external-chemvault-api": {
+        "BaseUrl": "http://localhost:10001/",
+        "HealthPath": "/config/health",
+        "TimeoutSeconds": 5
       }
     }
   },

--- a/src/ApiGateways/SimpleGW/SimpleGW.API/appsettings.json
+++ b/src/ApiGateways/SimpleGW/SimpleGW.API/appsettings.json
@@ -42,6 +42,16 @@
         "TimeoutSeconds": 10,
         "HealthPath": "/health"
       }
+    },
+    "ExternalServices": {
+      "external:foo": {
+        "BaseUrl": "https://example-foo.local",
+        "HealthPath": "/health",
+        "TimeoutSeconds": 3
+      },
+      "external:bar": {
+        "BaseUrl": "https://example-bar.local"
+      }
     }
   },
 

--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -47,6 +47,9 @@ services:
       - "EndPointRouting:user-preferences=http://user-preferences-api"
       - "EndPointRouting:aggregators=http://aggregators-api"
       - "EndPointRouting:event-management=http://event-management-api"
+      - "HealthPolling:ExternalServices:external-cf-nuisance:BaseUrl=http://cage_fusion_nuisance_api:10002/cage-fusion-api"
+      - "HealthPolling:ExternalServices:external-chemvault-api:BaseUrl=http://daikon_chem_vault_api:10001/"
+      - "HealthPolling:ExternalServices:external-chemvault-api:HealthPath=/config/health"
 
     ports:
       - "8010:80"


### PR DESCRIPTION
### Motivation
- Provide a way to poll external, health-only endpoints that are not part of the internal `EndPointRouting` map. 
- Allow per-target overrides (health path / timeout) for external targets while keeping internal routing unchanged. 
- Keep the aggregated health snapshot produced by `IMicroserviceHealthStore` unchanged so `/health/services` continues to return a single combined view.

### Description
- Added `HealthPollingOptions.ExternalServices` and a new `HealthPollingTarget` model with `BaseUrl`, optional `HealthPath`, and optional `TimeoutSeconds` in `HealthPollingOptions.cs`.
- Extended `MicroserviceHealthPoller` to load `HealthPolling:ExternalServices` and include those targets in the same polling loop as `EndPointRouting` targets via a unified `PollTarget` record, while retaining the existing `EndPointRouting` polling logic.
- External targets are polled directly with `ExternalServices[*].BaseUrl` and are not written into or mutated into `EndPointRouting`.
- Added example external entries to `appsettings.json` under `HealthPolling:ExternalServices` using distinctive keys (e.g. `external:foo`) to avoid collisions with internal routes.
- Left `IMicroserviceHealthStore` usage unchanged so both internal and external health results are updated into the same snapshot returned by `/health/services`.

Files changed: `src/ApiGateways/SimpleGW/SimpleGW.API/Services/HealthPollingOptions.cs`, `src/ApiGateways/SimpleGW/SimpleGW.API/Services/MicroserviceHealthPoller.cs`, `src/ApiGateways/SimpleGW/SimpleGW.API/appsettings.json`.

### Testing
- Ran JSON validation of the modified configuration with `python -m json.tool src/ApiGateways/SimpleGW/SimpleGW.API/appsettings.json` and it succeeded.
- Attempted to run `dotnet build src/daikon.sln`, but the `dotnet` CLI is not available in this environment so a full compile could not be executed.
- No unit tests were modified; existing runtime behavior for `/health/services` remains covered by the unchanged `IMicroserviceHealthStore` usage and was manually inspected in code to ensure combined snapshot semantics remain intact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974444c684c832c936cf6899f4b8536)